### PR TITLE
feat: Add authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,11 @@
+# Public
 CORS_ORIGINS=http://localhost:5173
 PORT=8080
 LOG_FORMAT=pretty
 LOG_LEVEL=debug
 UPLOAD_DIR=./uploads
+
+# Secret
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+JWT_SECRET=

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/terrabitz/rpg-audio-streamer
 go 1.23.4
 
 require (
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/gorilla/websocket v1.5.3
 	github.com/joho/godotenv v1.5.1
 	github.com/urfave/cli/v2 v2.27.5

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.5 h1:ZtcqGrnekaHpVLArFSe4HK5DoKx1T0rq2DwVB0alcyc=
 github.com/cpuguy83/go-md2man/v2 v2.0.5/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=

--- a/internal/auth/github.go
+++ b/internal/auth/github.go
@@ -1,0 +1,78 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+type GitHubConfig struct {
+	ClientID     string
+	ClientSecret string
+	JWTSecret    string
+}
+
+type GitHubUser struct {
+	ID        int    `json:"id"`
+	Login     string `json:"login"`
+	Name      string `json:"name"`
+	Email     string `json:"email"`
+	AvatarURL string `json:"avatar_url"`
+}
+
+func ExchangeCodeForToken(code string, config GitHubConfig) (string, error) {
+	// Exchange code for GitHub access token
+	tokenURL := fmt.Sprintf("https://github.com/login/oauth/access_token"+
+		"?client_id=%s&client_secret=%s&code=%s",
+		config.ClientID, config.ClientSecret, code)
+
+	req, _ := http.NewRequest("POST", tokenURL, nil)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to get access token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("failed to decode access token response: %w", err)
+	}
+
+	// Get user info using the access token
+	userReq, _ := http.NewRequest("GET", "https://api.github.com/user", nil)
+	userReq.Header.Set("Authorization", "Bearer "+result.AccessToken)
+	userResp, err := http.DefaultClient.Do(userReq)
+	if err != nil {
+		return "", fmt.Errorf("failed to get user info: %w", err)
+	}
+	defer userResp.Body.Close()
+
+	var user GitHubUser
+	if err := json.NewDecoder(userResp.Body).Decode(&user); err != nil {
+		return "", fmt.Errorf("failed to decode user info: %w", err)
+	}
+
+	// Create JWT
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"sub":        user.ID,
+		"name":       user.Name,
+		"login":      user.Login,
+		"email":      user.Email,
+		"avatar_url": user.AvatarURL,
+		"exp":        time.Now().Add(24 * time.Hour).Unix(),
+	})
+
+	tokenString, err := token.SignedString([]byte(config.JWTSecret))
+	if err != nil {
+		return "", fmt.Errorf("failed to create JWT: %w", err)
+	}
+
+	return tokenString, nil
+}

--- a/internal/auth/github.go
+++ b/internal/auth/github.go
@@ -76,3 +76,23 @@ func ExchangeCodeForToken(code string, config GitHubConfig) (string, error) {
 
 	return tokenString, nil
 }
+
+// ValidateToken validates the JWT token and returns the claims if valid
+func ValidateToken(tokenString string, jwtSecret string) (jwt.MapClaims, error) {
+	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+		return []byte(jwtSecret), nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse token: %w", err)
+	}
+
+	if claims, ok := token.Claims.(jwt.MapClaims); ok && token.Valid {
+		return claims, nil
+	}
+
+	return nil, fmt.Errorf("invalid token")
+}

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -1,0 +1,135 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+type Service struct {
+	config GitHubConfig
+	logger *slog.Logger
+}
+
+func NewService(config GitHubConfig, logger *slog.Logger) *Service {
+	return &Service{
+		config: config,
+		logger: logger,
+	}
+}
+
+func (s *Service) HandleGitHubLogin(w http.ResponseWriter, r *http.Request) {
+	redirectURL := fmt.Sprintf("https://github.com/login/oauth/authorize?client_id=%s&scope=user:email",
+		s.config.ClientID)
+	http.Redirect(w, r, redirectURL, http.StatusTemporaryRedirect)
+}
+
+func (s *Service) HandleGitHubCallback(w http.ResponseWriter, r *http.Request) {
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		http.Error(w, "Code not found", http.StatusBadRequest)
+		return
+	}
+
+	token, err := ExchangeCodeForToken(code, s.config)
+	if err != nil {
+		s.logger.Error("failed to exchange code for token", "error", err)
+		http.Error(w, "Authentication failed", http.StatusInternalServerError)
+		return
+	}
+
+	s.setAuthCookie(w, token)
+	http.Redirect(w, r, "http://localhost:5173/", http.StatusTemporaryRedirect)
+}
+
+type UserClaims struct {
+	AvatarURL string `json:"avatar_url"`
+	Email     string `json:"email"`
+	Exp       int64  `json:"exp"`
+	Login     string `json:"login"`
+	Name      string `json:"name"`
+	Sub       int    `json:"sub"`
+}
+
+func (s *Service) HandleAuthStatus(w http.ResponseWriter, r *http.Request) {
+	isAuthenticated := false
+	isAuthorized := false
+	var userData *UserClaims
+
+	if claims, err := s.ValidateRequest(r); err == nil {
+		isAuthenticated = true
+		userData = claims
+		isAuthorized = s.IsAuthorized(r)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"authenticated": isAuthenticated,
+		"authorized":    isAuthorized,
+		"user":          userData,
+	})
+}
+
+func (s *Service) HandleLogout(w http.ResponseWriter, r *http.Request) {
+	s.clearAuthCookie(w)
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *Service) ValidateRequest(r *http.Request) (*UserClaims, error) {
+	cookie, err := r.Cookie("auth_token")
+	if err != nil {
+		return nil, fmt.Errorf("no auth cookie: %w", err)
+	}
+
+	claims, err := ValidateToken(cookie.Value, s.config.JWTSecret)
+	if err != nil {
+		return nil, fmt.Errorf("invalid token: %w", err)
+	}
+
+	var userClaims UserClaims
+	claimsBytes, err := json.Marshal(claims)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal claims: %w", err)
+	}
+
+	if err := json.Unmarshal(claimsBytes, &userClaims); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal claims: %w", err)
+	}
+
+	return &userClaims, nil
+}
+
+func (s *Service) IsAuthorized(r *http.Request) bool {
+	claims, err := s.ValidateRequest(r)
+	if err != nil {
+		return false
+	}
+
+	return claims.Login == "terrabitz"
+}
+
+func (s *Service) setAuthCookie(w http.ResponseWriter, token string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     "auth_token",
+		Value:    token,
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteNoneMode,
+		MaxAge:   int((24 * time.Hour).Seconds()), // 24 hours
+	})
+}
+
+func (s *Service) clearAuthCookie(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     "auth_token",
+		Value:    "",
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteNoneMode,
+		MaxAge:   -1,
+	})
+}

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -44,19 +44,10 @@ func (s *Service) HandleGitHubCallback(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, "http://localhost:5173/", http.StatusTemporaryRedirect)
 }
 
-type UserClaims struct {
-	AvatarURL string `json:"avatar_url"`
-	Email     string `json:"email"`
-	Exp       int64  `json:"exp"`
-	Login     string `json:"login"`
-	Name      string `json:"name"`
-	Sub       int    `json:"sub"`
-}
-
 func (s *Service) HandleAuthStatus(w http.ResponseWriter, r *http.Request) {
 	isAuthenticated := false
 	isAuthorized := false
-	var userData *UserClaims
+	var userData *GitHubUser
 
 	if claims, err := s.ValidateRequest(r); err == nil {
 		isAuthenticated = true
@@ -77,7 +68,7 @@ func (s *Service) HandleLogout(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-func (s *Service) ValidateRequest(r *http.Request) (*UserClaims, error) {
+func (s *Service) ValidateRequest(r *http.Request) (*GitHubUser, error) {
 	cookie, err := r.Cookie("auth_token")
 	if err != nil {
 		return nil, fmt.Errorf("no auth cookie: %w", err)
@@ -88,17 +79,17 @@ func (s *Service) ValidateRequest(r *http.Request) (*UserClaims, error) {
 		return nil, fmt.Errorf("invalid token: %w", err)
 	}
 
-	var userClaims UserClaims
+	var GitHubUser GitHubUser
 	claimsBytes, err := json.Marshal(claims)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal claims: %w", err)
 	}
 
-	if err := json.Unmarshal(claimsBytes, &userClaims); err != nil {
+	if err := json.Unmarshal(claimsBytes, &GitHubUser); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal claims: %w", err)
 	}
 
-	return &userClaims, nil
+	return &GitHubUser, nil
 }
 
 func (s *Service) IsAuthorized(r *http.Request) bool {

--- a/internal/middlewares/auth.go
+++ b/internal/middlewares/auth.go
@@ -6,23 +6,11 @@ import (
 	"github.com/terrabitz/rpg-audio-streamer/internal/auth"
 )
 
-func AuthMiddleware(jwtSecret string) func(http.Handler) http.Handler {
+func AuthMiddleware(authService *auth.Service) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			cookie, err := r.Cookie("auth_token")
-			if err != nil {
+			if !authService.IsAuthorized(r) {
 				http.Error(w, "Unauthorized", http.StatusUnauthorized)
-				return
-			}
-
-			claims, err := auth.ValidateToken(cookie.Value, jwtSecret)
-			if err != nil {
-				http.Error(w, "Invalid token", http.StatusUnauthorized)
-				return
-			}
-
-			if username, ok := claims["login"].(string); !ok || username != "terrabitz" {
-				http.Error(w, "Unauthorized user", http.StatusForbidden)
 				return
 			}
 

--- a/internal/middlewares/auth.go
+++ b/internal/middlewares/auth.go
@@ -1,0 +1,32 @@
+package middlewares
+
+import (
+	"net/http"
+
+	"github.com/terrabitz/rpg-audio-streamer/internal/auth"
+)
+
+func AuthMiddleware(jwtSecret string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			cookie, err := r.Cookie("auth_token")
+			if err != nil {
+				http.Error(w, "Unauthorized", http.StatusUnauthorized)
+				return
+			}
+
+			claims, err := auth.ValidateToken(cookie.Value, jwtSecret)
+			if err != nil {
+				http.Error(w, "Invalid token", http.StatusUnauthorized)
+				return
+			}
+
+			if username, ok := claims["login"].(string); !ok || username != "terrabitz" {
+				http.Error(w, "Unauthorized user", http.StatusForbidden)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/middlewares/cors.go
+++ b/internal/middlewares/cors.go
@@ -14,8 +14,9 @@ func CORSMiddleware(cfg CorsConfig) func(http.Handler) http.Handler {
 			if cfg.AllowedOrigins != "" {
 				w.Header().Set("Access-Control-Allow-Origin", cfg.AllowedOrigins)
 				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
-				w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+				w.Header().Set("Access-Control-Allow-Headers", "*")
 				w.Header().Set("Access-Control-Max-Age", "3600")
+				w.Header().Set("Access-Control-Allow-Credentials", "true")
 			}
 
 			if r.Method == "OPTIONS" {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -77,6 +77,7 @@ func (s *Server) Start() error {
 	httpMux.HandleFunc("/api/v1/auth/github", s.handleGitHubAuth)
 	httpMux.HandleFunc("/api/v1/auth/github/callback", s.handleGitHubCallback)
 	httpMux.HandleFunc("/api/v1/auth/status", s.handleAuthStatus)
+	httpMux.HandleFunc("/api/v1/auth/logout", s.handleLogout)
 	mux.Handle("/", middlewares.LoggerMiddleware(s.logger)(
 		middlewares.CORSMiddleware(s.cfg.CORS)(httpMux),
 	))
@@ -282,4 +283,18 @@ func (s *Server) handleAuthStatus(w http.ResponseWriter, r *http.Request) {
 		"authenticated": isAuthenticated,
 		"user":          userData,
 	})
+}
+
+func (s *Server) handleLogout(w http.ResponseWriter, r *http.Request) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     "auth_token",
+		Value:    "",
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteNoneMode,
+		MaxAge:   -1,
+	})
+
+	w.WriteHeader(http.StatusOK)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -86,7 +86,7 @@ func (s *Server) Start() error {
 		middlewares.CORSMiddleware(s.cfg.CORS)(httpMux),
 	))
 
-	mux.HandleFunc("/ws", s.handleWebSocket)
+	mux.HandleFunc("/api/v1/ws", s.handleWebSocket)
 
 	srv := &http.Server{
 		Addr:    fmt.Sprintf(":%d", s.cfg.Port),

--- a/main.go
+++ b/main.go
@@ -14,8 +14,6 @@ import (
 	"github.com/terrabitz/rpg-audio-streamer/internal/server"
 )
 
-var uploadDir = "./uploads"
-
 //go:embed all:ui/dist
 var frontend embed.FS
 
@@ -75,6 +73,27 @@ func main() {
 						Value:       "./uploads",
 						Usage:       "Directory to store uploaded files",
 						Destination: &cfg.Server.UploadDir,
+					},
+					&cli.StringFlag{
+						Name:        "github-client-id",
+						EnvVars:     []string{"GITHUB_CLIENT_ID"},
+						Usage:       "GitHub OAuth Client ID",
+						Required:    true,
+						Destination: &cfg.Server.GitHub.ClientID,
+					},
+					&cli.StringFlag{
+						Name:        "github-client-secret",
+						EnvVars:     []string{"GITHUB_CLIENT_SECRET"},
+						Usage:       "GitHub OAuth Client Secret",
+						Required:    true,
+						Destination: &cfg.Server.GitHub.ClientSecret,
+					},
+					&cli.StringFlag{
+						Name:        "jwt-secret",
+						EnvVars:     []string{"JWT_SECRET"},
+						Usage:       "Secret key for signing JWTs",
+						Required:    true,
+						Destination: &cfg.Server.GitHub.JWTSecret,
 					},
 				},
 				Action: func(cCtx *cli.Context) error {

--- a/ui/src/components/GitHubLoginButton.vue
+++ b/ui/src/components/GitHubLoginButton.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+const handleLogin = () => {
+  const baseUrl = import.meta.env.VITE_API_BASE_URL
+  window.location.href = `${baseUrl}/auth/github`
+}
+</script>
+
+<template>
+  <v-btn @click="handleLogin">
+    Login with GitHub
+  </v-btn>
+</template>

--- a/ui/src/components/UserMenu.vue
+++ b/ui/src/components/UserMenu.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import { useAuthStore } from '../stores/auth';
+
+const auth = useAuthStore()
+
+const handleLogout = async () => {
+  await auth.logout()
+}
+</script>
+
+<template>
+  <div v-if="auth.user" class="flex items-center gap-3">
+    <div class="flex items-center gap-2">
+      <img :src="auth.user.avatar_url" :alt="auth.user.name" class="w-8 h-8 rounded-full" />
+      <span class="text-sm font-medium">{{ auth.user.name }}</span>
+    </div>
+    <button @click="handleLogout"
+      class="px-3 py-1.5 text-sm text-gray-700 hover:text-gray-900 hover:bg-gray-100 rounded">
+      Logout
+    </button>
+  </div>
+</template>

--- a/ui/src/components/UserMenu.vue
+++ b/ui/src/components/UserMenu.vue
@@ -9,10 +9,15 @@ const handleLogout = async () => {
 </script>
 
 <template>
-  <div v-if="auth.user" class="flex items-center gap-3">
+  <div v-if="auth.user" class="flex flex-col items-start gap-2">
     <div class="flex items-center gap-2">
       <img :src="auth.user.avatar_url" :alt="auth.user.name" class="w-8 h-8 rounded-full" />
-      <span class="text-sm font-medium">{{ auth.user.name }}</span>
+      <div class="flex flex-col">
+        <span class="text-sm font-medium">{{ auth.user.name }}</span>
+        <span v-if="!auth.authorized" class="text-xs text-red-600">
+          User {{ auth.user.login }} is not authorized to use this app
+        </span>
+      </div>
     </div>
     <button @click="handleLogout"
       class="px-3 py-1.5 text-sm text-gray-700 hover:text-gray-900 hover:bg-gray-100 rounded">

--- a/ui/src/composables/useWebSocket.ts
+++ b/ui/src/composables/useWebSocket.ts
@@ -11,7 +11,7 @@ interface WSMessage {
 function getWebSocketUrl(): string {
   const apiUrl = new URL(import.meta.env.VITE_API_BASE_URL)
   const wsProtocol = apiUrl.protocol === 'https:' ? 'wss:' : 'ws:'
-  return `${wsProtocol}//${apiUrl.host}/ws`
+  return `${wsProtocol}//${apiUrl.host}${apiUrl.pathname}/ws`
 }
 
 export function useWebSocket(onMessage: (message: WSMessage) => void) {

--- a/ui/src/plugins/axios.ts
+++ b/ui/src/plugins/axios.ts
@@ -5,6 +5,7 @@ import VueAxios from 'vue-axios'
 
 export const apiClient = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
+  withCredentials: true,
   headers: {
     'Content-Type': 'application/json'
   }

--- a/ui/src/stores/auth.ts
+++ b/ui/src/stores/auth.ts
@@ -1,28 +1,44 @@
 import { apiClient } from '@/plugins/axios'
+import type { AuthResponse, User } from '@/types/auth'
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 
 export const useAuthStore = defineStore('auth', () => {
   const authenticated = ref(false)
   const loading = ref(true)
-  const user = ref(null)
+  const user = ref<User | null>(null)
 
   async function checkAuthStatus() {
     try {
       const response = await apiClient.get(`/auth/status`)
-      authenticated.value = response.data.authenticated
-      user.value = response.data.user
+      const data = response.data as AuthResponse
+
+      authenticated.value = data.authenticated
+      user.value = data.user
     } catch (error) {
       console.error('Failed to check auth status:', error)
       authenticated.value = false
+      user.value = null
     } finally {
       loading.value = false
+    }
+  }
+
+  async function logout() {
+    try {
+      await apiClient.get(`/auth/logout`)
+      authenticated.value = false
+      user.value = null
+    } catch (error) {
+      console.error('Failed to logout:', error)
     }
   }
 
   return {
     authenticated,
     loading,
-    checkAuthStatus
+    user,
+    checkAuthStatus,
+    logout
   }
 })

--- a/ui/src/stores/auth.ts
+++ b/ui/src/stores/auth.ts
@@ -1,0 +1,28 @@
+import { apiClient } from '@/plugins/axios'
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export const useAuthStore = defineStore('auth', () => {
+  const authenticated = ref(false)
+  const loading = ref(true)
+  const user = ref(null)
+
+  async function checkAuthStatus() {
+    try {
+      const response = await apiClient.get(`/auth/status`)
+      authenticated.value = response.data.authenticated
+      user.value = response.data.user
+    } catch (error) {
+      console.error('Failed to check auth status:', error)
+      authenticated.value = false
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return {
+    authenticated,
+    loading,
+    checkAuthStatus
+  }
+})

--- a/ui/src/stores/auth.ts
+++ b/ui/src/stores/auth.ts
@@ -5,6 +5,7 @@ import { ref } from 'vue'
 
 export const useAuthStore = defineStore('auth', () => {
   const authenticated = ref(false)
+  const authorized = ref(false)
   const loading = ref(true)
   const user = ref<User | null>(null)
 
@@ -14,10 +15,12 @@ export const useAuthStore = defineStore('auth', () => {
       const data = response.data as AuthResponse
 
       authenticated.value = data.authenticated
+      authorized.value = data.authorized
       user.value = data.user
     } catch (error) {
       console.error('Failed to check auth status:', error)
       authenticated.value = false
+      authorized.value = false
       user.value = null
     } finally {
       loading.value = false
@@ -36,6 +39,7 @@ export const useAuthStore = defineStore('auth', () => {
 
   return {
     authenticated,
+    authorized,
     loading,
     user,
     checkAuthStatus,

--- a/ui/src/types/auth.ts
+++ b/ui/src/types/auth.ts
@@ -1,0 +1,13 @@
+export interface User {
+  sub: number
+  name: string
+  login: string
+  email: string
+  avatar_url: string
+  exp: number
+}
+
+export interface AuthResponse {
+  authenticated: boolean
+  user: User | null
+}

--- a/ui/src/types/auth.ts
+++ b/ui/src/types/auth.ts
@@ -1,13 +1,11 @@
 export interface User {
-  sub: number
-  name: string
-  login: string
-  email: string
-  avatar_url: string
-  exp: number
+  login: string;
+  name: string;
+  avatar_url: string;
 }
 
 export interface AuthResponse {
-  authenticated: boolean
-  user: User | null
+  authenticated: boolean;
+  authorized: boolean;
+  user: User | null;
 }

--- a/ui/src/views/HomeView.vue
+++ b/ui/src/views/HomeView.vue
@@ -3,6 +3,7 @@ import { onMounted } from 'vue'
 import AudioUploader from '../components/AudioUploader.vue'
 import FileList from '../components/FileList.vue'
 import GitHubLoginButton from '../components/GitHubLoginButton.vue'
+import UserMenu from '../components/UserMenu.vue'
 import { useAuthStore } from '../stores/auth'
 
 const auth = useAuthStore()
@@ -16,8 +17,9 @@ onMounted(() => {
   <main class="container mx-auto px-4 py-8">
     <div class="flex justify-between items-center mb-8">
       <h1 class="text-2xl font-bold">RPG Audio Streamer</h1>
-      <div v-if="!auth.loading && !auth.authenticated">
-        <GitHubLoginButton />
+      <div v-if="!auth.loading">
+        <UserMenu v-if="auth.authenticated" />
+        <GitHubLoginButton v-else />
       </div>
     </div>
 

--- a/ui/src/views/HomeView.vue
+++ b/ui/src/views/HomeView.vue
@@ -1,11 +1,41 @@
 <script setup lang="ts">
-import AudioUploader from '../components/AudioUploader.vue';
-import FileList from '../components/FileList.vue'; /* PartiallyEnd: #3632/scriptSetup.vue */
+import { onMounted } from 'vue'
+import AudioUploader from '../components/AudioUploader.vue'
+import FileList from '../components/FileList.vue'
+import GitHubLoginButton from '../components/GitHubLoginButton.vue'
+import { useAuthStore } from '../stores/auth'
+
+const auth = useAuthStore()
+
+onMounted(() => {
+  auth.checkAuthStatus()
+})
 </script>
 
 <template>
-  <main>
-    <AudioUploader />
-    <FileList />
+  <main class="container mx-auto px-4 py-8">
+    <div class="flex justify-between items-center mb-8">
+      <h1 class="text-2xl font-bold">RPG Audio Streamer</h1>
+      <div v-if="!auth.loading && !auth.authenticated">
+        <GitHubLoginButton />
+      </div>
+    </div>
+
+    <template v-if="auth.loading">
+      <div class="text-center py-12">
+        <p>Loading...</p>
+      </div>
+    </template>
+
+    <template v-else-if="auth.authenticated">
+      <AudioUploader />
+      <FileList />
+    </template>
+    <template v-else>
+      <div class="text-center py-12">
+        <h2 class="text-xl mb-4">Welcome to RPG Audio Streamer</h2>
+        <p class="text-gray-600 mb-6">Please login to start managing your audio files</p>
+      </div>
+    </template>
   </main>
 </template>

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -20,5 +20,11 @@ export default defineConfig({
   server: {
     host: true, // Listen on all local IPs
     port: 5173, // Default Vite port
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      },
+    },
   }
 })

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
     proxy: {
       '/api': {
         target: 'http://localhost:8080',
+        ws: true,
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
This pull request introduces GitHub OAuth authentication to the RPG Audio Streamer project. The changes include setting up the necessary configurations, implementing the authentication flow, and updating the frontend to support user login and logout functionalities.

Authentication Implementation:

* [`.env.example`](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR1-R11): Added environment variables for GitHub OAuth and JWT secrets.
* [`internal/auth/github.go`](diffhunk://#diff-32bac35f20f2c1af115559e693928ab4ad2bf767c11eea5815f1c648b2af7da6R1-R98): Implemented functions to exchange GitHub OAuth code for access tokens and to validate JWT tokens.
* [`internal/auth/service.go`](diffhunk://#diff-cff705e23a461e09c022c2359b0aa7cc262cdbedc0af78bec5b06d4d63098e9dR1-R126): Created a service to handle GitHub login, callback, authentication status, and logout.
* [`internal/middlewares/auth.go`](diffhunk://#diff-49219975528ba55c94a2569c1dda8e2281c5e45a6baa5af70916b78fc361df10R1-R20): Added an authentication middleware to protect API endpoints.
* [`internal/server/server.go`](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23R15-R27): Integrated the authentication service and middleware into the server setup. [[1]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23R15-R27) [[2]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23R38-R56) [[3]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23R73-R89)

Frontend Updates:

* [`ui/src/components/GitHubLoginButton.vue`](diffhunk://#diff-15b1fff9bcd9a52ab9fdf53287122519573886611097f50551523ead34b461dcR1-R12): Added a button component for GitHub login.
* [`ui/src/components/UserMenu.vue`](diffhunk://#diff-0c79724bf04b3557e036cc23df03fbe89576765fa29382b96546cbe3ddc7f51dR1-R27): Created a user menu component to display user info and handle logout.
* [`ui/src/stores/auth.ts`](diffhunk://#diff-3dd574cd1ba2459a0ee754976bcb7df838fdf6bdcbc8d142e5f6f5d7ade97e94R1-R48): Defined a Pinia store to manage authentication state.
* [`ui/src/views/HomeView.vue`](diffhunk://#diff-aff2f778c8b686dd7eec39c9e9508c3bbc29f4ff7c9732dd7d2fdaf13a9fd294L2-R41): Updated the home view to include authentication status checks and conditional rendering based on user login state.

Other Changes:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R6): Added the `github.com/golang-jwt/jwt/v5` dependency.
* [`internal/middlewares/cors.go`](diffhunk://#diff-96b28debff9555072b7b1d64ed7d11590cc78373b3a4315ff32ab55f35832bfbL17-R19): Updated CORS middleware to allow credentials.
* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R77-R97): Added CLI flags for GitHub OAuth and JWT secret configurations.
* [`ui/src/plugins/axios.ts`](diffhunk://#diff-d64aa6dd5e341c9370882477ff9999c0e8d603d91dd6567db57fcd281f846b27R8): Configured Axios to include credentials in requests.
* [`ui/vite.config.ts`](diffhunk://#diff-3ac010a0a7c98e20e2a93940f788480b80115f74ebbe72c7254b3e3bcdbc3c8eR23-R29): Set up a proxy for API requests in the Vite development server configuration.