### PR TITLE
feat: Add master volume control and sync with audio player

### DIFF
--- a/ui/src/components/AudioTrackPlayer.vue
+++ b/ui/src/components/AudioTrackPlayer.vue
@@ -54,7 +54,7 @@ function startAudioSync(fileName: string, videoElement: HTMLVideoElement) {
 
 function syncStateToVideoElement(state: AudioTrack, videoElement: HTMLVideoElement) {
   // Always sync these properties
-  videoElement.volume = state.volume / 100
+  videoElement.volume = (state.volume / 100) * (audioStore.masterVolume / 100)
   videoElement.loop = state.isRepeating
 
   if (state.isPlaying && videoElement.paused) {

--- a/ui/src/stores/audio.ts
+++ b/ui/src/stores/audio.ts
@@ -23,7 +23,8 @@ function newAudioTrack(fileName: string): AudioTrack {
 export const useAudioStore = defineStore('audio', {
   state: () => ({
     tracks: {} as Record<string, AudioTrack>,
-    enabled: false
+    enabled: false,
+    masterVolume: 100
   }),
   getters: {
     availableTracks: (state) => Object.values(state.tracks)

--- a/ui/src/views/PlayerView.vue
+++ b/ui/src/views/PlayerView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useWebSocketStore } from '@/stores/websocket'
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import PlayerFileList from '../components/PlayerFileList.vue'
 import { useAudioStore } from '../stores/audio'
@@ -11,6 +11,7 @@ const router = useRouter()
 const ws = useWebSocketStore()
 const audioStore = useAudioStore()
 const connecting = ref(false)
+const masterVolume = ref(100)
 
 const buttonLabel = computed(() => {
   if (connecting.value) return 'Connecting...'
@@ -29,6 +30,7 @@ function handleAudioToggle() {
   if (!audioStore.enabled) {
     connecting.value = true
     audioStore.enabled = true
+    audioStore.masterVolume = masterVolume.value
     ws.broadcast('syncRequest', {})
     setTimeout(() => {
       connecting.value = false
@@ -37,13 +39,17 @@ function handleAudioToggle() {
     audioStore.enabled = false
   }
 }
+
+watch(masterVolume, (newVolume) => {
+  audioStore.masterVolume = newVolume
+})
 </script>
 
 <template>
   <v-container>
     <AudioPlayer v-if="audioStore.enabled" />
     <div class="d-flex align-center mb-4">
-      <h1 class="mr-4">Table View</h1>
+      <h1 class="mr-4">Player View</h1>
       <v-chip v-if="audioStore.enabled" :color="ws.isConnected ? 'success' : 'error'" class="mr-4">
         {{ ws.isConnected ? 'Connected' : 'Disconnected' }}
       </v-chip>
@@ -52,6 +58,29 @@ function handleAudioToggle() {
       </v-btn>
     </div>
 
+    <v-card class="mt-4 audio-slider-card" border="sm" density="compact">
+      <v-card-title>Master Volume</v-card-title>
+      <v-card-text class="audio-slider-container">
+        <v-slider class="audio-slider mr-8 mt-2" v-model="masterVolume" min="0" max="100" prepend-icon="$volume" />
+      </v-card-text>
+    </v-card>
+
     <PlayerFileList v-if="audioStore.enabled" />
   </v-container>
 </template>
+
+<style scoped>
+.audio-slider-card {
+  max-width: 500px;
+}
+
+.audio-slider-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.audio-slider {
+  width: 100%;
+}
+</style>


### PR DESCRIPTION
This PR adds a new player-controlled master audio slider. This will allow the player to control the volume of their own audio streams.

![image](https://github.com/user-attachments/assets/6d1edba5-5b85-4d86-90a7-d1561e3d4f3e)
