### PR TITLE
feat: Implement track type checks for simultaneous playback prevention

### DIFF
--- a/ui/src/stores/files.ts
+++ b/ui/src/stores/files.ts
@@ -13,6 +13,11 @@ export const useFileStore = defineStore('files', {
   state: () => ({
     tracks: [] as Track[]
   }),
+  getters: {
+    getTrackById: (state) => {
+      return (id: string) => state.tracks.find(track => track.id === id)
+    }
+  },
   actions: {
     async fetchFiles() {
       try {


### PR DESCRIPTION
Introduce checks to prevent simultaneous playback of tracks based on their type. This ensures that when a track is played, other tracks of the same type are stopped if they do not allow simultaneous play.

![Kapture 2025-02-15 at 15 24 08](https://github.com/user-attachments/assets/b205c722-f678-4612-b3eb-b59e08a206b5)
