### PR TITLE
feat: Add track type sliders for players

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,7 @@
 
 Tasks to complete before releasing to my players:
 - [ ] Fix reconnection bug
+- [ ] Add track type mixer
 - [ ] Infrastructure setup
 
 Tasks to complete before GA of self-hostable:

--- a/TODO.md
+++ b/TODO.md
@@ -27,3 +27,8 @@ Additional tasks:
 - [ ] API docs
 - [ ] Integration with other streaming providers (YouTube, Spotify)
 - [ ] Discord integration
+
+
+Bugs:
+- [ ] Fix issue with audio bounce when master volume is adjusted while fading
+- [ ] Fix issue with track reset in player view when navigating away

--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,9 @@
 # TODO
 
 Tasks to complete before releasing to my players:
-- [ ] Fix reconnection bug
-- [ ] Add track type mixer
+- [X] Fix reconnection bug
+- [X] Add player track type mixer
+- [ ] Add GM track type mixer
 - [ ] Infrastructure setup
 
 Tasks to complete before GA of self-hostable:

--- a/internal/server/stores.go
+++ b/internal/server/stores.go
@@ -17,7 +17,7 @@ type Track struct {
 	CreatedAt time.Time `json:"createdAt,omitempty"`
 	Name      string    `json:"name,omitempty"`
 	Path      string    `json:"path,omitempty"`
-	TypeID    uuid.UUID `json:"type_id,omitempty"`
+	TypeID    uuid.UUID `json:"typeID,omitempty"`
 }
 
 type TrackStore interface {

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -34,7 +34,7 @@ wsStore.addMessageHandler((message) => {
   if (message.method === 'syncRequest' && auth.role === 'gm') {
     // Send current state to requesting client
     wsStore.broadcast('syncAll', {
-      tracks: audioStore.getAllTrackStates(),
+      tracks: audioStore.getPlayingTracks(),
       to: message.senderId,
     })
   }

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, watch } from 'vue';
-import { RouterLink, RouterView, useRouter } from 'vue-router';
+import { computed, onMounted, onUnmounted, watch } from 'vue';
+import { RouterLink, RouterView, useRoute, useRouter } from 'vue-router';
 import DevDebugPanel from './components/DevDebugPanel.vue';
 import { useAudioStore } from './stores/audio';
 import { useAuthStore } from './stores/auth';
@@ -12,6 +12,8 @@ const router = useRouter()
 const wsStore = useWebSocketStore()
 const debugStore = useDebugStore()
 const audioStore = useAudioStore()
+const route = useRoute()
+const isPlayerView = computed(() => route.path === '/player')
 
 async function handleLogout() {
   await auth.logout()
@@ -51,20 +53,22 @@ onUnmounted(() => {
   <v-app theme="dark">
     <v-app-bar>
       <v-app-bar-title>
-        <RouterLink to="/" class="text-decoration-none" style="color: inherit">
+        <RouterLink v-if="!isPlayerView" to="/" class="text-decoration-none" style="color: inherit">
           <v-icon icon="custom:lute" class="mr-2" size="small" />
           Skald Bot
         </RouterLink>
+        <span v-else>
+          <v-icon icon="custom:lute" class="mr-2" size="small" />
+          Skald Bot
+        </span>
       </v-app-bar-title>
       <v-spacer></v-spacer>
       <v-btn v-if="debugStore.isDevMode" icon="$bug" @click="debugStore.togglePanel"></v-btn>
-      <template v-if="auth.authenticated">
-        <v-btn @click="handleLogout" color="error">
+      <template v-if="!isPlayerView">
+        <v-btn v-if="auth.authenticated" @click="handleLogout" color="error">
           Logout
         </v-btn>
-      </template>
-      <template v-else>
-        <v-btn to="/login" color="primary">
+        <v-btn v-else to="/login" color="primary">
           Login
         </v-btn>
       </template>

--- a/ui/src/components/AudioControls.vue
+++ b/ui/src/components/AudioControls.vue
@@ -38,7 +38,7 @@ const trackTypeStore = useTrackTypeStore();
 const fileStore = useFileStore();
 
 const track = computed(() => fileStore.tracks.find(t => t.id === props.fileID));
-const trackType = computed(() => track.value ? trackTypeStore.getTypeById(track.value.type_id) : null);
+const trackType = computed(() => track.value ? trackTypeStore.getTypeById(track.value.typeID) : null);
 const audioState = computed(() => audioStore.tracks[props.fileID]);
 const fadeState = computed(() => audioStore.fadeStates[props.fileID]);
 

--- a/ui/src/components/AudioControls.vue
+++ b/ui/src/components/AudioControls.vue
@@ -9,9 +9,10 @@
       {{ trackType.isRepeating ? '$repeat' : '$repeatOff' }}
     </v-icon>
     <div class="d-flex align-center mr-2" style="min-width: 120px">
-      <v-icon size="x-small" class="mr-2">$volume</v-icon>
+      <VolumeSlider v-model="audioState.volume" @update:model-value="$emit('volume', $event)" />
+      <!-- <v-icon size="x-small" class="mr-2">$volume</v-icon>
       <v-slider :model-value="audioState.volume" @update:model-value="$emit('volume', $event)" density="compact"
-        hide-details max="100" min="0" step="1"></v-slider>
+        hide-details max="100" min="0" step="1"></v-slider> -->
     </div>
     <div class="d-flex align-center" style="min-width: 300px">
       <span class="text-caption mr-2">{{ formatTime(audioState.currentTime) }}</span>
@@ -27,6 +28,7 @@ import { computed, watchEffect } from 'vue';
 import { useAudioStore } from '../stores/audio';
 import { useFileStore } from '../stores/files';
 import { useTrackTypeStore } from '../stores/trackTypes';
+import VolumeSlider from './VolumeSlider.vue';
 
 const props = defineProps<{
   fileName: string

--- a/ui/src/components/AudioTrackPlayer.vue
+++ b/ui/src/components/AudioTrackPlayer.vue
@@ -65,6 +65,10 @@ function startAudioSync(fileID: string, videoElement: HTMLVideoElement) {
     syncVolume(fileID, videoElement)
   })
 
+  watch(() => audioStore.masterVolume, () => {
+    syncVolumeImmediate(fileID, videoElement)
+  })
+
   watch(() => audioStore.tracks[fileID].isRepeating, () => {
     syncRepeating(fileID, videoElement)
   })
@@ -118,6 +122,7 @@ function syncVolume(fileID: string, videoElement: HTMLVideoElement) {
     // Start fade if volume is different
     let currentFadeStep = 0
     fadeTimer = setInterval(() => {
+      console.log("fading", currentFadeStep, FADE_STEPS)
       currentFadeStep++
       if (currentFadeStep >= FADE_STEPS) {
         // We're done fading; stop the video if desired and clear the timer
@@ -135,6 +140,12 @@ function syncVolume(fileID: string, videoElement: HTMLVideoElement) {
       videoElement.volume = newVolume
     }, FADE_STEP_DURATION)
   }
+}
+
+function syncVolumeImmediate(fileID: string, videoElement: HTMLVideoElement) {
+  const desiredState = audioStore.tracks[fileID]
+  const desiredVolume = (desiredState.volume / 100) * (audioStore.masterVolume / 100)
+  videoElement.volume = desiredVolume
 }
 
 function syncRepeating(fileID: string, videoElement: HTMLVideoElement) {

--- a/ui/src/components/AudioTrackPlayer.vue
+++ b/ui/src/components/AudioTrackPlayer.vue
@@ -122,7 +122,6 @@ function syncVolume(fileID: string, videoElement: HTMLVideoElement) {
     // Start fade if volume is different
     let currentFadeStep = 0
     fadeTimer = setInterval(() => {
-      console.log("fading", currentFadeStep, FADE_STEPS)
       currentFadeStep++
       if (currentFadeStep >= FADE_STEPS) {
         // We're done fading; stop the video if desired and clear the timer

--- a/ui/src/components/AudioUploader.vue
+++ b/ui/src/components/AudioUploader.vue
@@ -1,7 +1,11 @@
 <template>
   <div>
-    <v-btn @click="showModal = true">Upload Track</v-btn>
     <v-dialog persistent v-model="showModal" max-width="600px">
+      <template v-slot:activator="{ props }">
+        <v-btn v-bind="props" prepend-icon="$upload">
+          Upload Track
+        </v-btn>
+      </template>
       <v-card>
         <v-card-title>
           <span class="headline">Upload Track</span>

--- a/ui/src/components/FileList.vue
+++ b/ui/src/components/FileList.vue
@@ -12,8 +12,8 @@
         <tr v-for="file in fileStore.tracks" :key="file.id">
           <td>{{ file.name }}</td>
           <td>
-            <v-chip :color="getTrackType(file.type_id)?.color" text-color="white">
-              {{ getTrackType(file.type_id)?.name }}
+            <v-chip :color="getTrackType(file.typeID)?.color" text-color="white">
+              {{ getTrackType(file.typeID)?.name }}
             </v-chip>
           </td>
           <td class="d-flex align-center">
@@ -65,7 +65,7 @@ const handlePlay = (fileID: string) => {
   const track = fileStore.getTrackById(fileID)
   if (!track) return
 
-  const trackType = trackTypeStore.getTypeById(track.type_id)
+  const trackType = trackTypeStore.getTypeById(track.typeID)
   if (!trackType) return
 
   const state = audioStore.tracks[fileID]
@@ -78,7 +78,7 @@ const handlePlay = (fileID: string) => {
       if (otherID !== fileID && otherTrack.isPlaying) {
         // Check if other track is of the same type
         const otherTrackData = fileStore.getTrackById(otherID)
-        if (otherTrackData && otherTrackData.type_id === track.type_id) {
+        if (otherTrackData && otherTrackData.typeID === track.typeID) {
           // Stop the other track
           audioStore.updateTrackState(otherID, { isPlaying: false })
           wsStore.sendMessage('syncTrack', {

--- a/ui/src/components/FileList.vue
+++ b/ui/src/components/FileList.vue
@@ -68,8 +68,12 @@ const handlePlay = (fileID: string) => {
   const trackType = trackTypeStore.getTypeById(track.typeID)
   if (!trackType) return
 
-  const state = audioStore.tracks[fileID]
-  const newState = { isPlaying: !state.isPlaying }
+  const state = audioStore.tracks[fileID] || {}
+  const newState = {
+    isPlaying: !state.isPlaying,
+    trackType: trackType.name,
+    name: track.name
+  }
 
   // If we're starting playback and the track type doesn't allow simultaneous play
   if (newState.isPlaying && !trackType.allowSimultaneousPlay) {

--- a/ui/src/components/FileList.vue
+++ b/ui/src/components/FileList.vue
@@ -19,9 +19,7 @@
           <td class="d-flex align-center">
             <AudioControls :fileID="file.id" :fileName="file.name" @play="handlePlay(file.id)"
               @volume="vol => handleVolume(file.id, vol)" @seek="time => handleSeek(file.id, time)" />
-            <v-btn icon size="small" color="error" @click="deleteFile(file)">
-              <v-icon>$delete</v-icon>
-            </v-btn>
+            <v-btn class="ml-3" icon="$delete" size="small" color="error" @click="deleteFile(file)" />
           </td>
         </tr>
       </tbody>

--- a/ui/src/components/VolumeSlider.vue
+++ b/ui/src/components/VolumeSlider.vue
@@ -3,7 +3,6 @@ import { ref } from 'vue';
 
 const props = defineProps<{
   modelValue: number
-  label?: string
   color?: string
 }>()
 
@@ -44,8 +43,8 @@ function colorForVolume() {
 </script>
 
 <template>
-  <v-slider step="1" :model-value="modelValue" @update:model-value="updateValue" min="0" max="100" :label="label"
-    :color="color" hide-details density="compact">
+  <v-slider step="1" :model-value="modelValue" @update:model-value="updateValue" min="0" max="100" :color="color"
+    hide-details density="compact">
     <template #prepend>
       <v-icon size="20" :color="colorForVolume()" :icon="iconForVolume()" @click="toggleMute"></v-icon>
     </template>

--- a/ui/src/components/VolumeSlider.vue
+++ b/ui/src/components/VolumeSlider.vue
@@ -36,7 +36,7 @@ function iconForVolume() {
 }
 
 function colorForVolume() {
-  if (props.modelValue == 0) return 'grey-lighten-1'
+  if (props.modelValue == 0) return 'grey-darken-1'
 
   return 'grey-lighten-4'
 }
@@ -46,7 +46,7 @@ function colorForVolume() {
   <v-slider step="1" :model-value="modelValue" @update:model-value="updateValue" min="0" max="100" :color="color"
     hide-details density="compact">
     <template #prepend>
-      <v-icon size="20" :color="colorForVolume()" :icon="iconForVolume()" @click="toggleMute"></v-icon>
+      <v-icon size="22" :color="colorForVolume()" :icon="iconForVolume()" @click="toggleMute"></v-icon>
     </template>
   </v-slider>
 </template>

--- a/ui/src/components/VolumeSlider.vue
+++ b/ui/src/components/VolumeSlider.vue
@@ -35,23 +35,19 @@ function iconForVolume() {
   if (props.modelValue > 0) return '$volumeLow'
   return '$volumeOff'
 }
+
+function colorForVolume() {
+  if (props.modelValue == 0) return 'grey-lighten-1'
+
+  return 'grey-lighten-4'
+}
 </script>
 
 <template>
-  <div class="audio-slider-container">
-    <v-slider class="audio-slider mr-8" :model-value="modelValue" @update:model-value="updateValue" min="0" max="100"
-      :label="label" :color="color" :prepend-icon="iconForVolume()" @click:prepend="toggleMute" />
-  </div>
+  <v-slider step="1" :model-value="modelValue" @update:model-value="updateValue" min="0" max="100" :label="label"
+    :color="color" hide-details density="compact">
+    <template #prepend>
+      <v-icon size="20" :color="colorForVolume()" :icon="iconForVolume()" @click="toggleMute"></v-icon>
+    </template>
+  </v-slider>
 </template>
-
-<style scoped>
-.audio-slider-container {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.audio-slider {
-  width: 100%;
-}
-</style>

--- a/ui/src/components/VolumeSlider.vue
+++ b/ui/src/components/VolumeSlider.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+
+const props = defineProps<{
+  modelValue: number
+  label?: string
+  color?: string
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: number): void
+}>()
+
+const previousVolume = ref(props.modelValue)
+
+function updateValue(value: number) {
+  if (value > 0) {
+    previousVolume.value = value
+  }
+  emit('update:modelValue', value)
+}
+
+function toggleMute() {
+  if (props.modelValue === 0) {
+    updateValue(previousVolume.value || 100)
+  } else {
+    previousVolume.value = props.modelValue
+    updateValue(0)
+  }
+}
+
+function iconForVolume() {
+  if (props.modelValue > 66) return '$volumeHigh'
+  if (props.modelValue > 33) return '$volumeMedium'
+  if (props.modelValue > 0) return '$volumeLow'
+  return '$volumeOff'
+}
+</script>
+
+<template>
+  <div class="audio-slider-container">
+    <v-slider class="audio-slider mr-8" :model-value="modelValue" @update:model-value="updateValue" min="0" max="100"
+      :label="label" :color="color" :prepend-icon="iconForVolume()" @click:prepend="toggleMute" />
+  </div>
+</template>
+
+<style scoped>
+.audio-slider-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.audio-slider {
+  width: 100%;
+}
+</style>

--- a/ui/src/plugins/vuetify.ts
+++ b/ui/src/plugins/vuetify.ts
@@ -1,5 +1,5 @@
 import IconLute from '@/components/icons/IconLute.vue';
-import { mdiBug, mdiCircle, mdiContentCopy, mdiDelete, mdiHome, mdiLoading, mdiMusic, mdiPause, mdiPlay, mdiRefresh, mdiRepeat, mdiRepeatOff, mdiUpload, mdiVolumeHigh } from '@mdi/js';
+import { mdiBug, mdiCircle, mdiContentCopy, mdiDelete, mdiHome, mdiLoading, mdiMusic, mdiPause, mdiPlay, mdiRefresh, mdiRepeat, mdiRepeatOff, mdiUpload, mdiVolumeHigh, mdiVolumeLow, mdiVolumeMedium, mdiVolumeOff } from '@mdi/js';
 import { h } from 'vue';
 import { createVuetify, type IconProps, type IconSet } from 'vuetify';
 import { aliases, mdi } from 'vuetify/iconsets/mdi-svg';
@@ -33,6 +33,10 @@ export default createVuetify({
       refresh: mdiRefresh,
       loading: mdiLoading,
       upload: mdiUpload,
+      volumeHigh: mdiVolumeHigh,
+      volumeMedium: mdiVolumeMedium,
+      volumeLow: mdiVolumeLow,
+      volumeOff: mdiVolumeOff,
     },
     sets: {
       mdi,

--- a/ui/src/plugins/vuetify.ts
+++ b/ui/src/plugins/vuetify.ts
@@ -1,5 +1,5 @@
 import IconLute from '@/components/icons/IconLute.vue';
-import { mdiBug, mdiCircle, mdiContentCopy, mdiDelete, mdiHome, mdiLoading, mdiMusic, mdiPause, mdiPlay, mdiRefresh, mdiRepeat, mdiRepeatOff, mdiVolumeHigh } from '@mdi/js';
+import { mdiBug, mdiCircle, mdiContentCopy, mdiDelete, mdiHome, mdiLoading, mdiMusic, mdiPause, mdiPlay, mdiRefresh, mdiRepeat, mdiRepeatOff, mdiUpload, mdiVolumeHigh } from '@mdi/js';
 import { h } from 'vue';
 import { createVuetify, type IconProps, type IconSet } from 'vuetify';
 import { aliases, mdi } from 'vuetify/iconsets/mdi-svg';
@@ -32,6 +32,7 @@ export default createVuetify({
       circle: mdiCircle,
       refresh: mdiRefresh,
       loading: mdiLoading,
+      upload: mdiUpload,
     },
     sets: {
       mdi,

--- a/ui/src/stores/audio.ts
+++ b/ui/src/stores/audio.ts
@@ -33,7 +33,8 @@ export const useAudioStore = defineStore('audio', {
     tracks: {} as Record<string, AudioTrack>,
     enabled: false,
     masterVolume: 100,
-    fadeStates: {} as Record<string, FadeStatus>
+    fadeStates: {} as Record<string, FadeStatus>,
+    typeVolumes: {} as Record<string, number>,
   }),
   getters: {
     availableTracks: (state) => Object.values(state.tracks)
@@ -58,7 +59,6 @@ export const useAudioStore = defineStore('audio', {
     getPlayingTracks() {
       return Object.values(this.tracks)
         .filter(track => track.isPlaying)
-
     },
     syncTracks(tracks: Partial<AudioTrack>[]) {
       // Only sync tracks if audio is enabled
@@ -87,6 +87,13 @@ export const useAudioStore = defineStore('audio', {
         this.fadeStates[fileID] = { inProgress: false }
       }
       this.fadeStates[fileID].inProgress = isFading
+    },
+    setTypeVolume(typeName: string, volume: number) {
+      this.typeVolumes[typeName] = volume
+    },
+
+    getTypeVolume(typeName: string): number {
+      return this.typeVolumes[typeName] ?? 100
     }
   }
 })

--- a/ui/src/stores/audio.ts
+++ b/ui/src/stores/audio.ts
@@ -8,13 +8,14 @@ export interface AudioTrack {
   isRepeating: boolean
   currentTime: number
   duration: number
+  trackType: string
 }
 
 interface FadeStatus {
   inProgress: boolean
 }
 
-function newAudioTrack(fileID: string, name: string): AudioTrack {
+function newAudioTrack(fileID: string, name: string, typeId: string = ""): AudioTrack {
   return {
     fileID,
     name,
@@ -22,7 +23,8 @@ function newAudioTrack(fileID: string, name: string): AudioTrack {
     volume: 100,
     isRepeating: false,
     currentTime: 0,
-    duration: 0
+    duration: 0,
+    trackType: "",
   }
 }
 
@@ -37,13 +39,14 @@ export const useAudioStore = defineStore('audio', {
     availableTracks: (state) => Object.values(state.tracks)
   },
   actions: {
-    initTrack(fileID: string, name: string) {
+    initTrack(fileID: string, name: string, typeId: string = "") {
       if (!this.tracks[fileID]) {
-        this.tracks[fileID] = newAudioTrack(fileID, name)
+        this.tracks[fileID] = newAudioTrack(fileID, name, typeId)
       }
     },
     updateTrackState(fileID: string, updates: Partial<AudioTrack>) {
       const track = this.tracks[fileID] ? this.tracks[fileID] : newAudioTrack(fileID, "")
+
       this.tracks[fileID] = {
         ...track,
         ...updates
@@ -52,16 +55,10 @@ export const useAudioStore = defineStore('audio', {
     removeTrack(fildID: string) {
       delete this.tracks[fildID]
     },
-    getAllTrackStates() {
+    getPlayingTracks() {
       return Object.values(this.tracks)
-        .filter(track => track.isPlaying)  // Only include playing tracks
-        .map(track => ({
-          fileID: track.fileID,
-          isPlaying: track.isPlaying,
-          volume: track.volume,
-          isRepeating: track.isRepeating,
-          currentTime: track.currentTime
-        }))
+        .filter(track => track.isPlaying)
+
     },
     syncTracks(tracks: Partial<AudioTrack>[]) {
       // Only sync tracks if audio is enabled

--- a/ui/src/stores/files.ts
+++ b/ui/src/stores/files.ts
@@ -6,7 +6,7 @@ export interface Track {
   createdAt: string
   name: string
   path: string
-  type_id: string
+  typeID: string
 }
 
 export const useFileStore = defineStore('files', {

--- a/ui/src/views/PlayerView.vue
+++ b/ui/src/views/PlayerView.vue
@@ -51,7 +51,8 @@ watch(masterVolume, (newVolume) => {
   <v-container>
     <AudioPlayer v-if="audioStore.enabled" />
     <div class="d-flex align-center mb-4">
-      <v-btn @click="handleAudioToggle" :loading="connecting" :color="audioStore.enabled ? 'error' : 'success'">
+      <v-btn size="x-large" @click="handleAudioToggle" :loading="connecting"
+        :color="audioStore.enabled ? 'error' : 'success'">
         {{ buttonLabel }}
       </v-btn>
       <v-chip v-if="audioStore.enabled" :color="ws.isConnected ? 'success' : 'error'" class="ml-4">

--- a/ui/src/views/PlayerView.vue
+++ b/ui/src/views/PlayerView.vue
@@ -73,10 +73,17 @@ watch(masterVolume, (newVolume) => {
     <v-card class="mt-4 audio-slider-card" border="sm" density="compact">
       <v-card-title>Volume Mixer</v-card-title>
       <v-card-text>
-        <VolumeSlider v-model="masterVolume" class="mb-4" />
-        <v-divider class="mb-4" />
-        <VolumeSlider v-for="type in trackTypeStore.trackTypes" :key="type.id"
-          v-model="audioStore.typeVolumes[type.name]" :color="type.color" class="mb-4" />
+        <div class="mixer-controls">
+          <div class="mixer-row">
+            <span class="mixer-label">Master</span>
+            <VolumeSlider v-model="masterVolume" class="mixer-slider" />
+          </div>
+          <v-divider class="my-4" />
+          <div v-for="type in trackTypeStore.trackTypes" :key="type.id" class="mixer-row">
+            <span class="mixer-label">{{ type.name }}</span>
+            <VolumeSlider v-model="audioStore.typeVolumes[type.name]" :color="type.color" class="mixer-slider" />
+          </div>
+        </div>
       </v-card-text>
     </v-card>
 
@@ -97,5 +104,24 @@ watch(masterVolume, (newVolume) => {
 
 .audio-slider {
   width: 100%;
+}
+
+.mixer-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.mixer-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.mixer-label {
+  width: 100px;
+  flex-shrink: 0;
+  font-size: 1.0rem;
+  font-weight: 600;
 }
 </style>

--- a/ui/src/views/PlayerView.vue
+++ b/ui/src/views/PlayerView.vue
@@ -5,6 +5,7 @@ import { useWebSocketStore } from '@/stores/websocket'
 import { computed, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import PlayerFileList from '../components/PlayerFileList.vue'
+import VolumeSlider from '../components/VolumeSlider.vue'
 import { useAudioStore } from '../stores/audio'
 import { useAuthStore } from '../stores/auth'
 
@@ -72,14 +73,9 @@ watch(masterVolume, (newVolume) => {
     <v-card class="mt-4 audio-slider-card" border="sm" density="compact">
       <v-card-title>Volume Mixer</v-card-title>
       <v-card-text>
-        <div class="audio-slider-container mb-4">
-          <v-slider class="audio-slider mr-8" v-model="masterVolume" min="0" max="100" label="Master"
-            prepend-icon="$volume" />
-        </div>
-        <div v-for="type in trackTypeStore.trackTypes" :key="type.id" class="audio-slider-container mb-4">
-          <v-slider class="audio-slider mr-8" v-model="audioStore.typeVolumes[type.name]" min="0" max="100"
-            :label="type.name" :color="type.color" prepend-icon="$volume" />
-        </div>
+        <VolumeSlider v-model="masterVolume" label="Master" class="mb-4" />
+        <VolumeSlider v-for="type in trackTypeStore.trackTypes" :key="type.id"
+          v-model="audioStore.typeVolumes[type.name]" :label="type.name" :color="type.color" class="mb-4" />
       </v-card-text>
     </v-card>
 

--- a/ui/src/views/PlayerView.vue
+++ b/ui/src/views/PlayerView.vue
@@ -74,6 +74,7 @@ watch(masterVolume, (newVolume) => {
       <v-card-title>Volume Mixer</v-card-title>
       <v-card-text>
         <VolumeSlider v-model="masterVolume" label="Master" class="mb-4" />
+        <v-divider class="mb-4" />
         <VolumeSlider v-for="type in trackTypeStore.trackTypes" :key="type.id"
           v-model="audioStore.typeVolumes[type.name]" :label="type.name" :color="type.color" class="mb-4" />
       </v-card-text>

--- a/ui/src/views/PlayerView.vue
+++ b/ui/src/views/PlayerView.vue
@@ -73,10 +73,10 @@ watch(masterVolume, (newVolume) => {
     <v-card class="mt-4 audio-slider-card" border="sm" density="compact">
       <v-card-title>Volume Mixer</v-card-title>
       <v-card-text>
-        <VolumeSlider v-model="masterVolume" label="Master" class="mb-4" />
+        <VolumeSlider v-model="masterVolume" class="mb-4" />
         <v-divider class="mb-4" />
         <VolumeSlider v-for="type in trackTypeStore.trackTypes" :key="type.id"
-          v-model="audioStore.typeVolumes[type.name]" :label="type.name" :color="type.color" class="mb-4" />
+          v-model="audioStore.typeVolumes[type.name]" :color="type.color" class="mb-4" />
       </v-card-text>
     </v-card>
 

--- a/ui/src/views/PlayerView.vue
+++ b/ui/src/views/PlayerView.vue
@@ -49,13 +49,12 @@ watch(masterVolume, (newVolume) => {
   <v-container>
     <AudioPlayer v-if="audioStore.enabled" />
     <div class="d-flex align-center mb-4">
-      <h1 class="mr-4">Player View</h1>
-      <v-chip v-if="audioStore.enabled" :color="ws.isConnected ? 'success' : 'error'" class="mr-4">
-        {{ ws.isConnected ? 'Connected' : 'Disconnected' }}
-      </v-chip>
       <v-btn @click="handleAudioToggle" :loading="connecting" :color="audioStore.enabled ? 'error' : 'success'">
         {{ buttonLabel }}
       </v-btn>
+      <v-chip v-if="audioStore.enabled" :color="ws.isConnected ? 'success' : 'error'" class="ml-4">
+        {{ ws.isConnected ? 'Connected' : 'Disconnected' }}
+      </v-chip>
     </div>
 
     <v-card class="mt-4 audio-slider-card" border="sm" density="compact">

--- a/ui/src/views/PlayerView.vue
+++ b/ui/src/views/PlayerView.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useDebugStore } from '@/stores/debug'
 import { useWebSocketStore } from '@/stores/websocket'
 import { computed, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
@@ -10,6 +11,7 @@ const auth = useAuthStore()
 const router = useRouter()
 const ws = useWebSocketStore()
 const audioStore = useAudioStore()
+const debugStore = useDebugStore()
 const connecting = ref(false)
 const masterVolume = ref(100)
 
@@ -64,7 +66,7 @@ watch(masterVolume, (newVolume) => {
       </v-card-text>
     </v-card>
 
-    <PlayerFileList v-if="audioStore.enabled" />
+    <PlayerFileList v-if="debugStore.isDevMode" />
   </v-container>
 </template>
 

--- a/ui/src/views/TableView.vue
+++ b/ui/src/views/TableView.vue
@@ -55,13 +55,14 @@ onMounted(() => {
 <template>
   <v-container class="px-4 py-8" style="max-width: 1000px">
     <AudioPlayer />
-    <div class="mb-8">
-      <h1>My Table</h1>
-      <div>
+    <div class="mb-8 d-flex align-center">
+      <h1 class="mr-4">My Table</h1>
+      <div class="d-flex">
         <v-btn v-if="auth.authenticated && auth.role === 'gm'" @click="handleGetJoinToken" :disabled="joinStore.loading"
-          :active="isCopied" width="200" active-color="green" :prepend-icon="isCopied ? '' : '$copy'">
+          :active="isCopied" width="200" active-color="green" :prepend-icon="isCopied ? '' : '$copy'" class="mr-4">
           {{ isCopied ? 'Copied to clipboard' : 'Get Join URL' }}
         </v-btn>
+        <AudioUploader v-if="auth.authenticated" />
       </div>
     </div>
 
@@ -72,7 +73,6 @@ onMounted(() => {
     </template>
 
     <template v-else-if="auth.authenticated">
-      <AudioUploader />
       <FileList />
     </template>
     <template v-else>

--- a/ui/src/views/TableView.vue
+++ b/ui/src/views/TableView.vue
@@ -55,8 +55,8 @@ onMounted(() => {
 <template>
   <v-container class="px-4 py-8" style="max-width: 1000px">
     <AudioPlayer />
-    <div class="mb-8 d-flex align-center">
-      <h1 class="mr-4">My Table</h1>
+    <div class="d-flex align-center">
+      <h1 class="mr-8">My Table</h1>
       <div class="d-flex">
         <v-btn v-if="auth.authenticated && auth.role === 'gm'" @click="handleGetJoinToken" :disabled="joinStore.loading"
           :active="isCopied" width="200" active-color="green" :prepend-icon="isCopied ? '' : '$copy'" class="mr-4">
@@ -65,6 +65,8 @@ onMounted(() => {
         <AudioUploader v-if="auth.authenticated" />
       </div>
     </div>
+
+    <v-divider class="mt-3 mb-1" />
 
     <template v-if="auth.loading">
       <div class="text-center py-12">


### PR DESCRIPTION
This PR adds new track type sliders for players. This will allow them to control their own mixing by track type (even if not by individual tracks). This will allow them to do things like disable certain types of tracks, or alter the mixing to their needs.

![Kapture 2025-02-16 at 23 08 17](https://github.com/user-attachments/assets/dc6cd881-2a8a-41e1-837c-c580cfb9e8dc)
