### PR TITLE
feat: Use Tiled Layout for Audio Tracks

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,10 +7,10 @@ Tasks to complete before releasing to my players:
 - [X] Infrastructure setup
 
 Tasks to complete before GA of self-hostable:
+- [X] Automate Docker image build
+- [X] Add example Docker and Docker Compose configurations
 - [ ] Better file management
 - [ ] Improve initial setup experience
-- [ ] Automate Docker image build
-- [ ] Add example Docker and Docker Compose configurations
 
 Tasks to complete before GA of hosted:
 - [ ] Landing page
@@ -23,10 +23,11 @@ Tasks to complete before GA of hosted:
 - [ ] Monetization (e.g. subscription for extra storage)
 
 Additional tasks:
-- [ ] Customizable tiled track layout
+- [X] API docs
+- [X] Tiled track layout
+- [ ] Customizable track order
 - [ ] Mobile layout support
 - [ ] Turn frontend into a PWA
-- [ ] API docs
 - [ ] Integration with other streaming providers (YouTube, Spotify)
 - [ ] Discord integration
 - [ ] Add automatic updates for the GIF demo on the README

--- a/media/audio-playing.gif
+++ b/media/audio-playing.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3ba1d85d68bc87ffdb0f0f28663eb35ed478a3a044b82bce9c4467ea385b5a7f
-size 281967
+oid sha256:7e94d582bfe98db78db0d8d693c19ed74360fb10fa25328c602105b0e1facad6
+size 538427

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -2,6 +2,7 @@
 import { computed, onMounted, onUnmounted, watch } from 'vue';
 import { RouterLink, RouterView, useRoute, useRouter } from 'vue-router';
 import DevDebugPanel from './components/DevDebugPanel.vue';
+import { useAppBar } from './composables/useAppBar';
 import { useAudioStore } from './stores/audio';
 import { useAuthStore } from './stores/auth';
 import { useDebugStore } from './stores/debug';
@@ -14,6 +15,8 @@ const debugStore = useDebugStore()
 const audioStore = useAudioStore()
 const route = useRoute()
 const isPlayerView = computed(() => route.path === '/player')
+
+const { title, actions } = useAppBar()
 
 async function handleLogout() {
   await auth.logout()
@@ -62,13 +65,16 @@ onUnmounted(() => {
       <v-app-bar-title>
         <RouterLink v-if="!isPlayerView" to="/" class="text-decoration-none" style="color: inherit">
           <v-icon icon="custom:lute" class="mr-2" size="small" />
-          Skald Bot
+          {{ title }}
         </RouterLink>
         <span v-else>
           <v-icon icon="custom:lute" class="mr-2" size="small" />
-          Skald Bot
+          {{ title }}
         </span>
       </v-app-bar-title>
+
+      <component v-for="(action, index) in actions" :key="index" :is="action" />
+
       <v-spacer></v-spacer>
       <v-btn v-if="debugStore.isDevMode" icon="$bug" @click="debugStore.togglePanel"></v-btn>
       <template v-if="!isPlayerView">

--- a/ui/src/components/AudioControls.vue
+++ b/ui/src/components/AudioControls.vue
@@ -27,16 +27,16 @@
           <v-btn icon="$close" size="small" variant="text" @click="showControls = false" class="float-right" />
         </v-card-title>
         <v-card-text>
-          <div class="d-flex flex-column gap-4 pa-2">
+          <div class="d-flex flex-column">
             <div class="d-flex align-center">
-              <v-icon size="small" color="grey-darken-1" class="mr-2">
-                {{ trackType.isRepeating ? '$repeat' : '$repeatOff' }}
-              </v-icon>
               <VolumeSlider v-model="audioState.volume" @update:model-value="$emit('volume', $event)" />
             </div>
             <div class="d-flex align-center">
+              <v-icon size="small" color="grey-darken-1" class="mx-2">
+                {{ trackType.isRepeating ? '$repeat' : '$repeatOff' }}
+              </v-icon>
               <v-slider :model-value="audioState.currentTime" @update:model-value="$emit('seek', $event)"
-                density="compact" hide-details :max="audioState.duration" min="0" step="0.1" class="mx-2" />
+                density="compact" hide-details :max="audioState.duration" min="0" step="0.1" class="ml-4" />
               <span class="text-caption ml-2">{{ formatTime(audioState.duration) }}</span>
             </div>
           </div>

--- a/ui/src/components/AudioControls.vue
+++ b/ui/src/components/AudioControls.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="trackType" class="audio-control-tile">
+  <div v-if="trackType" class="audio-control-tile" :class="{ 'is-active': isActive }">
     <div class="text-center pa-2 text-subtitle-1 position-relative">
       {{ props.fileName }}
       <v-btn icon="$dotsVertical" size="small" variant="text" @click.stop="showControls = true"
@@ -76,6 +76,28 @@ const fadeState = computed(() => audioStore.fadeStates[props.fileID]);
 
 const showControls = ref(false);
 
+const isActive = computed(() => audioState.value?.isPlaying);
+
+function darkenColor(color: string, amount: number): string {
+  // Convert hex to RGB
+  const r = parseInt(color.slice(1, 3), 16);
+  const g = parseInt(color.slice(3, 5), 16);
+  const b = parseInt(color.slice(5, 7), 16);
+
+  // Darken by amount
+  const darkerR = Math.floor(r * amount);
+  const darkerG = Math.floor(g * amount);
+  const darkerB = Math.floor(b * amount);
+
+  // Convert back to hex
+  return `#${darkerR.toString(16).padStart(2, '0')}${darkerG.toString(16).padStart(2, '0')}${darkerB.toString(16).padStart(2, '0')}`;
+}
+
+const darkerColor = computed(() => {
+  if (!trackType.value?.color) return '';
+  return darkenColor(trackType.value.color, 0.14);
+});
+
 // Wait for track type data before initializing audio track
 watchEffect(() => {
   if (trackType.value) {
@@ -108,6 +130,12 @@ function formatTime(seconds: number): string {
 
 .audio-control-tile {
   cursor: pointer;
+  height: 100%;
+  transition: background-color 0.3s ease;
+}
+
+.audio-control-tile.is-active {
+  background-color: v-bind('darkerColor');
 }
 
 .play-status {

--- a/ui/src/components/AudioControls.vue
+++ b/ui/src/components/AudioControls.vue
@@ -1,9 +1,9 @@
 <template>
   <div v-if="trackType" class="audio-control-tile" :class="{ 'is-active': isActive }">
-    <div class="text-center pa-2 text-subtitle-1 position-relative">
+    <div class="text-center pa-1 text-subtitle-1 position-relative">
       {{ props.fileName }}
       <v-btn icon="$dotsVertical" size="small" variant="text" @click.stop="showControls = true"
-        class="position-absolute top-0 right-0 mt-1 mr-1" />
+        class="position-absolute top-0 right-0" />
     </div>
     <v-divider></v-divider>
     <div class="d-flex flex-column pa-1 position-relative">

--- a/ui/src/components/AudioControls.vue
+++ b/ui/src/components/AudioControls.vue
@@ -6,14 +6,14 @@
         class="position-absolute top-0 right-0 mt-1 mr-1" />
     </div>
     <v-divider></v-divider>
-    <div class="d-flex flex-column pa-3 position-relative">
-      <div class="d-flex justify-space-between align-center">
-        <v-chip :color="trackType?.color" text-color="white" size="small" @click.stop>
+    <div class="d-flex flex-column pa-1 position-relative">
+      <div class="d-flex justify-space-between align-center mx-2">
+        <v-chip :color="trackType?.color" text-color="white" size="x-small" @click.stop>
           {{ trackType?.name }}
         </v-chip>
         <div class="play-status mr-2">
-          <v-progress-circular v-if="fadeState?.inProgress" width="3" size="24" indeterminate />
-          <v-icon v-else size="36">
+          <v-progress-circular v-if="fadeState?.inProgress" width="3" size="20" indeterminate />
+          <v-icon v-else size="24">
             {{ audioState.isPlaying ? '$pause' : '$play' }}
           </v-icon>
         </div>

--- a/ui/src/components/AudioControls.vue
+++ b/ui/src/components/AudioControls.vue
@@ -35,9 +35,11 @@
               <v-icon size="small" color="grey-darken-1" class="mx-2">
                 {{ trackType.isRepeating ? '$repeat' : '$repeatOff' }}
               </v-icon>
-              <v-slider :model-value="audioState.currentTime" @update:model-value="$emit('seek', $event)"
-                density="compact" hide-details :max="audioState.duration" min="0" step="0.1" class="ml-4" />
-              <span class="text-caption ml-2">{{ formatTime(audioState.duration) }}</span>
+              <v-slider thumb-size="0" :model-value="audioState.currentTime" readonly density="compact" hide-details
+                :max="audioState.duration" min="0" step="0.1" class="ml-3" />
+              <span class="text-caption ml-2">{{ formatTime(audioState.currentTime) }} / {{
+                formatTime(audioState.duration)
+              }}</span>
             </div>
           </div>
         </v-card-text>

--- a/ui/src/components/AudioControls.vue
+++ b/ui/src/components/AudioControls.vue
@@ -10,9 +10,6 @@
     </v-icon>
     <div class="d-flex align-center mr-2" style="min-width: 120px">
       <VolumeSlider v-model="audioState.volume" @update:model-value="$emit('volume', $event)" />
-      <!-- <v-icon size="x-small" class="mr-2">$volume</v-icon>
-      <v-slider :model-value="audioState.volume" @update:model-value="$emit('volume', $event)" density="compact"
-        hide-details max="100" min="0" step="1"></v-slider> -->
     </div>
     <div class="d-flex align-center" style="min-width: 300px">
       <span class="text-caption mr-2">{{ formatTime(audioState.currentTime) }}</span>

--- a/ui/src/components/FileList.vue
+++ b/ui/src/components/FileList.vue
@@ -1,29 +1,13 @@
 <template>
   <v-container>
-    <v-table>
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Type</th>
-          <th>Actions</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr v-for="file in fileStore.tracks" :key="file.id">
-          <td>{{ file.name }}</td>
-          <td>
-            <v-chip :color="getTrackType(file.typeID)?.color" text-color="white">
-              {{ getTrackType(file.typeID)?.name }}
-            </v-chip>
-          </td>
-          <td class="d-flex align-center">
-            <AudioControls :fileID="file.id" :fileName="file.name" @play="handlePlay(file.id)"
-              @volume="vol => handleVolume(file.id, vol)" @seek="time => handleSeek(file.id, time)" />
-            <v-btn class="ml-3" icon="$delete" size="small" color="error" @click="deleteFile(file)" />
-          </td>
-        </tr>
-      </tbody>
-    </v-table>
+    <v-row>
+      <v-col v-for="file in fileStore.tracks" :key="file.id" cols="6" sm="4" md="3" lg="2">
+        <v-card class="file-tile" @click="handlePlay(file.id)">
+          <AudioControls :fileID="file.id" :fileName="file.name" @volume="vol => handleVolume(file.id, vol)"
+            @seek="time => handleSeek(file.id, time)" @delete="deleteFile(file)" />
+        </v-card>
+      </v-col>
+    </v-row>
   </v-container>
 </template>
 
@@ -143,3 +127,14 @@ watch(() => audioStore.masterVolume, () => {
   updateAllTrackVolumes()
 })
 </script>
+
+<style scoped>
+.file-tile {
+  transition: all 0.2s ease;
+}
+
+.file-tile:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+</style>

--- a/ui/src/components/FileList.vue
+++ b/ui/src/components/FileList.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container>
-    <v-row>
+    <v-row :dense="true">
       <v-col v-for="file in fileStore.tracks" :key="file.id" cols="6" sm="4" md="3" lg="2">
         <v-card class="file-tile" @click="handlePlay(file.id)">
           <AudioControls :fileID="file.id" :fileName="file.name" @volume="vol => handleVolume(file.id, vol)"

--- a/ui/src/components/TableActions.vue
+++ b/ui/src/components/TableActions.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useBaseUrl } from '../composables/useBaseUrl'
+import { useAuthStore } from '../stores/auth'
+import { useJoinStore } from '../stores/join'
+import AudioUploader from './AudioUploader.vue'
+
+const auth = useAuthStore()
+const joinStore = useJoinStore()
+const { getBaseUrl } = useBaseUrl()
+const isCopied = ref(false)
+
+async function copyToClipboard(text: string) {
+  await navigator.clipboard.writeText(text)
+}
+
+async function handleGetJoinToken() {
+  await joinStore.fetchToken()
+  if (joinStore.token) {
+    const url = `${getBaseUrl()}/join/${joinStore.token}`
+    await copyToClipboard(url)
+    isCopied.value = true
+    setTimeout(() => {
+      isCopied.value = false
+    }, 2000)
+  }
+}
+</script>
+
+<template>
+  <template v-if="auth.authenticated">
+    <v-btn v-if="auth.role === 'gm'" @click="handleGetJoinToken" :disabled="joinStore.loading" :active="isCopied"
+      active-color="green" :prepend-icon="isCopied ? '' : '$copy'" class="mr-2">
+      {{ isCopied ? 'Copied to clipboard' : 'Get Join URL' }}
+    </v-btn>
+    <AudioUploader />
+  </template>
+</template>

--- a/ui/src/components/TableActions.vue
+++ b/ui/src/components/TableActions.vue
@@ -1,12 +1,16 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { useBaseUrl } from '../composables/useBaseUrl'
+import { useAudioStore } from '../stores/audio'
 import { useAuthStore } from '../stores/auth'
 import { useJoinStore } from '../stores/join'
 import AudioUploader from './AudioUploader.vue'
+import VolumeSlider from './VolumeSlider.vue'
 
 const auth = useAuthStore()
 const joinStore = useJoinStore()
+const audioStore = useAudioStore();
+
 const { getBaseUrl } = useBaseUrl()
 const isCopied = ref(false)
 
@@ -33,6 +37,7 @@ async function handleGetJoinToken() {
       active-color="green" :prepend-icon="isCopied ? '' : '$copy'" class="mr-2">
       {{ isCopied ? 'Copied to clipboard' : 'Get Join URL' }}
     </v-btn>
-    <AudioUploader />
+    <AudioUploader class="mr-4" />
+    <VolumeSlider v-model="audioStore.masterVolume" />
   </template>
 </template>

--- a/ui/src/composables/useAppBar.ts
+++ b/ui/src/composables/useAppBar.ts
@@ -1,0 +1,21 @@
+import { ref, type Component } from 'vue'
+
+const actions = ref<Component[]>([])
+const title = ref<string>('Skald Bot')
+
+export function useAppBar() {
+  function setActions(newActions: Component[]) {
+    actions.value = newActions
+  }
+
+  function setTitle(newTitle: string) {
+    title.value = newTitle
+  }
+
+  return {
+    actions,
+    title,
+    setActions,
+    setTitle
+  }
+}

--- a/ui/src/plugins/vuetify.ts
+++ b/ui/src/plugins/vuetify.ts
@@ -1,5 +1,5 @@
 import IconLute from '@/components/icons/IconLute.vue';
-import { mdiBug, mdiCircle, mdiContentCopy, mdiDelete, mdiHome, mdiLoading, mdiMusic, mdiPause, mdiPlay, mdiRefresh, mdiRepeat, mdiRepeatOff, mdiUpload, mdiVolumeHigh, mdiVolumeLow, mdiVolumeMedium, mdiVolumeOff } from '@mdi/js';
+import { mdiBug, mdiCircle, mdiContentCopy, mdiDelete, mdiDotsVertical, mdiHome, mdiLoading, mdiMusic, mdiPause, mdiPlay, mdiRefresh, mdiRepeat, mdiRepeatOff, mdiUpload, mdiVolumeHigh, mdiVolumeLow, mdiVolumeMedium, mdiVolumeOff } from '@mdi/js';
 import { h } from 'vue';
 import { createVuetify, type IconProps, type IconSet } from 'vuetify';
 import { aliases, mdi } from 'vuetify/iconsets/mdi-svg';
@@ -37,6 +37,7 @@ export default createVuetify({
       volumeMedium: mdiVolumeMedium,
       volumeLow: mdiVolumeLow,
       volumeOff: mdiVolumeOff,
+      dotsVertical: mdiDotsVertical,
     },
     sets: {
       mdi,

--- a/ui/src/views/TableView.vue
+++ b/ui/src/views/TableView.vue
@@ -76,7 +76,7 @@ onUnmounted(() => {
         <v-card class="audio-slider-card" border="sm" density="compact">
           <v-card-text class="d-flex align-center py-2">
             <span class="mr-4">Master Volume</span>
-            <VolumeSlider v-model="audioStore.masterVolume" class="flex-grow-1" />
+            <VolumeSlider v-model="audioStore.masterVolume" />
           </v-card-text>
         </v-card>
       </div>

--- a/ui/src/views/TableView.vue
+++ b/ui/src/views/TableView.vue
@@ -4,7 +4,6 @@ import { onMounted, onUnmounted, ref } from 'vue'
 import AudioPlayer from '../components/AudioPlayer.vue'
 import FileList from '../components/FileList.vue'
 import TableActions from '../components/TableActions.vue'
-import VolumeSlider from '../components/VolumeSlider.vue'
 import { useAppBar } from '../composables/useAppBar'
 import { useBaseUrl } from '../composables/useBaseUrl'
 import { useAuthStore } from '../stores/auth'
@@ -72,14 +71,6 @@ onUnmounted(() => {
     </template>
 
     <template v-else-if="auth.authenticated">
-      <div class="d-flex justify-center">
-        <v-card class="audio-slider-card" border="sm" density="compact">
-          <v-card-text class="d-flex align-center py-2">
-            <span class="mr-4">Master Volume</span>
-            <VolumeSlider v-model="audioStore.masterVolume" />
-          </v-card-text>
-        </v-card>
-      </div>
       <FileList />
     </template>
     <template v-else>
@@ -88,8 +79,4 @@ onUnmounted(() => {
   </v-container>
 </template>
 
-<style scoped>
-.audio-slider-card {
-  width: 400px;
-}
-</style>
+<style scoped></style>

--- a/ui/src/views/TableView.vue
+++ b/ui/src/views/TableView.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import { useAudioStore } from '@/stores/audio'
-import { onMounted, ref } from 'vue'
+import { onMounted, onUnmounted, ref } from 'vue'
 import AudioPlayer from '../components/AudioPlayer.vue'
-import AudioUploader from '../components/AudioUploader.vue'
 import FileList from '../components/FileList.vue'
+import TableActions from '../components/TableActions.vue'
 import VolumeSlider from '../components/VolumeSlider.vue'
+import { useAppBar } from '../composables/useAppBar'
 import { useBaseUrl } from '../composables/useBaseUrl'
 import { useAuthStore } from '../stores/auth'
 import { useJoinStore } from '../stores/join'
@@ -13,6 +14,7 @@ const auth = useAuthStore()
 const joinStore = useJoinStore()
 const audioStore = useAudioStore()
 const { getBaseUrl } = useBaseUrl()
+const { setTitle, setActions } = useAppBar()
 
 const joinUrl = ref<string>('')
 const isCopied = ref(false)
@@ -49,26 +51,20 @@ async function handleGetJoinToken() {
 }
 
 onMounted(() => {
+  setTitle('My Table')
+  setActions([TableActions])
   audioStore.enabled = true
+})
+
+onUnmounted(() => {
+  setActions([])
+  setTitle('Skald Bot')
 })
 </script>
 
 <template>
-  <v-container class="px-4 py-8" style="max-width: 1000px">
+  <v-container class="py-2">
     <AudioPlayer />
-    <div class="d-flex align-center">
-      <h1 class="mr-8">My Table</h1>
-      <div class="d-flex">
-        <v-btn v-if="auth.authenticated && auth.role === 'gm'" @click="handleGetJoinToken" :disabled="joinStore.loading"
-          :active="isCopied" width="200" active-color="green" :prepend-icon="isCopied ? '' : '$copy'" class="mr-4">
-          {{ isCopied ? 'Copied to clipboard' : 'Get Join URL' }}
-        </v-btn>
-        <AudioUploader v-if="auth.authenticated" />
-      </div>
-    </div>
-
-    <v-divider class="mt-3 mb-1" />
-
     <template v-if="auth.loading">
       <div class="text-center py-12">
         <p>Loading...</p>

--- a/ui/src/views/TableView.vue
+++ b/ui/src/views/TableView.vue
@@ -76,13 +76,14 @@ onMounted(() => {
     </template>
 
     <template v-else-if="auth.authenticated">
-      <v-card class="audio-slider-card" border="sm" density="compact">
-        <v-card-title>Volume Mixer</v-card-title>
-        <v-card-text>
-          <span class="mixer-label">Master</span>
-          <VolumeSlider v-model="audioStore.masterVolume" class="mixer-slider" />
-        </v-card-text>
-      </v-card>
+      <div class="d-flex justify-center">
+        <v-card class="audio-slider-card" border="sm" density="compact">
+          <v-card-text class="d-flex align-center py-2">
+            <span class="mr-4">Master Volume</span>
+            <VolumeSlider v-model="audioStore.masterVolume" class="flex-grow-1" />
+          </v-card-text>
+        </v-card>
+      </div>
       <FileList />
     </template>
     <template v-else>
@@ -93,6 +94,6 @@ onMounted(() => {
 
 <style scoped>
 .audio-slider-card {
-  max-width: 500px;
+  width: 400px;
 }
 </style>


### PR DESCRIPTION
This PR updates the table view to use a tiled layout for the audio tracks, producing a cleaner and more compact look:

![image](https://github.com/user-attachments/assets/ec5afed8-9363-441a-bced-1cb395147d04)


All the main table controls have been moved into the app bar in order to free up space. This allows us to have as many tiles on screen at a time as possible.