### PR TITLE
fix: Improve frontend routing for players

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -28,6 +28,7 @@ Tasks to complete before GA of hosted:
 Additional tasks:
 - [X] API docs
 - [X] Tiled track layout
+- [X] Make the player view URL the same as the join URL
 - [ ] Customizable track order
 - [ ] Mobile layout support
 - [ ] Turn frontend into a PWA
@@ -37,7 +38,6 @@ Additional tasks:
 - [ ] Better navigation (e.g. restricting access to login if we're authenticated, removing navigation to most pages as a player)
 - [ ] Save table audio state (i.e. volumes)
 - [ ] Add "always start track from beginning" option
-- [ ] Make the player view URL the same as the join URL
 
 Bugs:
 - [X] Fix issue with audio bounce when master volume is adjusted while fading

--- a/TODO.md
+++ b/TODO.md
@@ -10,6 +10,7 @@ Tasks to complete before GA of self-hostable:
 - [X] Automate Docker image build
 - [X] Add example Docker and Docker Compose configurations
 - [X] File metadata editing
+- [ ] Multiple tables
 - [ ] Better file management
 - [ ] Improve initial setup experience
 - [ ] Multiple tables
@@ -36,6 +37,7 @@ Additional tasks:
 - [ ] Better navigation (e.g. restricting access to login if we're authenticated, removing navigation to most pages as a player)
 - [ ] Save table audio state (i.e. volumes)
 - [ ] Add "always start track from beginning" option
+- [ ] Make the player view URL the same as the join URL
 
 Bugs:
 - [X] Fix issue with audio bounce when master volume is adjusted while fading

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -14,7 +14,10 @@ const wsStore = useWebSocketStore()
 const debugStore = useDebugStore()
 const audioStore = useAudioStore()
 const route = useRoute()
-const isPlayerView = computed(() => route.path === '/player')
+const isPlayerView = computed(() => {
+  // Check if we're in a player context within the table view
+  return route.name === 'table' && (!auth.authenticated || auth.role === 'player')
+})
 
 const { title, actions } = useAppBar()
 
@@ -50,8 +53,8 @@ wsStore.addMessageHandler((message) => {
   }
 })
 
-onMounted(() => {
-  auth.checkAuthStatus()
+onMounted(async () => {
+  await auth.checkAuthStatus()
 })
 
 onUnmounted(() => {

--- a/ui/src/components/TableActions.vue
+++ b/ui/src/components/TableActions.vue
@@ -21,7 +21,7 @@ async function copyToClipboard(text: string) {
 async function handleGetJoinToken() {
   await joinStore.fetchToken()
   if (joinStore.token) {
-    const url = `${getBaseUrl()}/join/${joinStore.token}`
+    const url = `${getBaseUrl()}/table/${joinStore.token}`
     await copyToClipboard(url)
     isCopied.value = true
     setTimeout(() => {

--- a/ui/src/plugins/vuetify.ts
+++ b/ui/src/plugins/vuetify.ts
@@ -1,5 +1,5 @@
 import IconLute from '@/components/icons/IconLute.vue';
-import { mdiAccountMusic, mdiBug, mdiCircle, mdiContentCopy, mdiDelete, mdiDotsVertical, mdiHome, mdiLoading, mdiLogin, mdiMusic, mdiPause, mdiPlay, mdiRefresh, mdiRepeat, mdiRepeatOff, mdiUpload, mdiVolumeHigh, mdiVolumeLow, mdiVolumeMedium, mdiVolumeOff } from '@mdi/js';
+import { mdiAccountMusic, mdiBug, mdiCircle, mdiContentCopy, mdiDelete, mdiDotsVertical, mdiHeadphones, mdiHome, mdiLoading, mdiLogin, mdiMusic, mdiPause, mdiPlay, mdiRefresh, mdiRepeat, mdiRepeatOff, mdiTableLarge, mdiUpload, mdiVolumeHigh, mdiVolumeLow, mdiVolumeMedium, mdiVolumeOff } from '@mdi/js';
 import { h } from 'vue';
 import { createVuetify, type IconProps, type IconSet } from 'vuetify';
 import { aliases, mdi } from 'vuetify/iconsets/mdi-svg';
@@ -40,6 +40,7 @@ export default createVuetify({
       dotsVertical: mdiDotsVertical,
       login: mdiLogin,
       accountMusic: mdiAccountMusic,
+      headphones: mdiHeadphones,
     },
     sets: {
       mdi,

--- a/ui/src/plugins/vuetify.ts
+++ b/ui/src/plugins/vuetify.ts
@@ -1,5 +1,5 @@
 import IconLute from '@/components/icons/IconLute.vue';
-import { mdiBug, mdiCircle, mdiContentCopy, mdiDelete, mdiDotsVertical, mdiHome, mdiLoading, mdiMusic, mdiPause, mdiPlay, mdiRefresh, mdiRepeat, mdiRepeatOff, mdiUpload, mdiVolumeHigh, mdiVolumeLow, mdiVolumeMedium, mdiVolumeOff } from '@mdi/js';
+import { mdiAccountMusic, mdiBug, mdiCircle, mdiContentCopy, mdiDelete, mdiDotsVertical, mdiHome, mdiLoading, mdiLogin, mdiMusic, mdiPause, mdiPlay, mdiRefresh, mdiRepeat, mdiRepeatOff, mdiUpload, mdiVolumeHigh, mdiVolumeLow, mdiVolumeMedium, mdiVolumeOff } from '@mdi/js';
 import { h } from 'vue';
 import { createVuetify, type IconProps, type IconSet } from 'vuetify';
 import { aliases, mdi } from 'vuetify/iconsets/mdi-svg';
@@ -38,6 +38,8 @@ export default createVuetify({
       volumeLow: mdiVolumeLow,
       volumeOff: mdiVolumeOff,
       dotsVertical: mdiDotsVertical,
+      login: mdiLogin,
+      accountMusic: mdiAccountMusic,
     },
     sets: {
       mdi,

--- a/ui/src/router/index.ts
+++ b/ui/src/router/index.ts
@@ -10,7 +10,7 @@ const router = createRouter({
       component: HomeView,
     },
     {
-      path: '/table',
+      path: '/table/:token?',
       name: 'table',
       component: () => import('../views/TableView.vue'),
     },
@@ -18,16 +18,6 @@ const router = createRouter({
       path: '/login',
       name: 'login',
       component: () => import('../views/LoginView.vue'),
-    },
-    {
-      path: '/join/:token',
-      name: 'join',
-      component: () => import('../views/JoinView.vue'),
-    },
-    {
-      path: '/player',
-      name: 'player',
-      component: () => import('../views/PlayerView.vue'),
     },
   ],
 })

--- a/ui/src/views/HomeView.vue
+++ b/ui/src/views/HomeView.vue
@@ -14,8 +14,7 @@ const auth = useAuthStore();
       </p>
 
       <div class="d-flex flex-wrap justify-center gap-4">
-        <v-btn to="/table" color="primary" size="large" variant="elevated">
-          <v-icon left>{{ auth.role === 'gm' ? 'mdi-table-large' : 'mdi-headphones' }}</v-icon>
+        <v-btn to="/table" color="primary" size="large" variant="elevated" prepend-icon="$headphones">
           {{ auth.role === 'gm' ? 'Go to My Table' : 'Connect to Audio' }}
         </v-btn>
       </div>

--- a/ui/src/views/HomeView.vue
+++ b/ui/src/views/HomeView.vue
@@ -1,15 +1,42 @@
 <script setup lang="ts">
 import { useAuthStore } from '../stores/auth';
 
-const auth = useAuthStore()
+const auth = useAuthStore();
 </script>
 
 <template>
-  <v-container>
-    <h1>Welcome to Skald Bot!</h1>
-    <div v-if="auth.authenticated">
-      <v-btn v-if="auth.role == 'gm'" to="table">My Table</v-btn>
-      <v-btn v-if="auth.role == 'player'" to="player">Connect to Table</v-btn>
+  <v-container class="text-center py-10">
+    <h1 class="text-h3 mb-6">Welcome to RPG Audio Streamer</h1>
+
+    <div v-if="auth.authenticated" class="d-flex flex-column align-center">
+      <p class="text-body-1 mb-4">
+        You are logged in as a {{ auth.role === 'gm' ? 'Game Master' : 'Player' }}
+      </p>
+
+      <div class="d-flex flex-wrap justify-center gap-4">
+        <v-btn to="/table" color="primary" size="large" variant="elevated">
+          <v-icon left>{{ auth.role === 'gm' ? 'mdi-table-large' : 'mdi-headphones' }}</v-icon>
+          {{ auth.role === 'gm' ? 'Go to My Table' : 'Connect to Audio' }}
+        </v-btn>
+      </div>
+    </div>
+
+    <div v-else class="d-flex flex-column align-center">
+      <p class="text-body-1 mb-6">
+        Join a game session or log in as a Game Master to manage audio for your game.
+      </p>
+
+      <div class="d-flex flex-wrap justify-center gap-4">
+
+        <v-btn to="/login" color="secondary" size="large" variant="elevated" prepend-icon="$login">
+          GM Login
+        </v-btn>
+
+        <v-btn class="ml-4" to="/table" color="primary" size="large" variant="elevated" prepend-icon="$accountMusic">
+          Join as Player
+        </v-btn>
+
+      </div>
     </div>
   </v-container>
 </template>

--- a/ui/src/views/TableView.vue
+++ b/ui/src/views/TableView.vue
@@ -2,10 +2,8 @@
 import { useAudioStore, type AudioTrack } from '@/stores/audio'
 import { useWebSocketStore } from '@/stores/websocket'
 import { computed, onMounted, onUnmounted, ref } from 'vue'
-import AudioPlayer from '../components/AudioPlayer.vue'
-import FileList from '../components/FileList.vue'
-import TableActions from '../components/TableActions.vue'
-import PlayerView from './PlayerView.vue'
+import TableViewGM from './TableViewGM.vue'
+import TableViewPlayer from './TableViewPlayer.vue'
 import { useAppBar } from '../composables/useAppBar'
 import { useAuthStore } from '../stores/auth'
 import { useJoinStore } from '../stores/join'
@@ -20,6 +18,10 @@ const joiningWithToken = ref(false)
 
 const isPlayerView = computed(() => {
   return auth.role === 'player' || !auth.authenticated
+})
+
+const isGMView = computed(() => {
+  return auth.role === 'gm' && auth.authenticated
 })
 
 function handleSyncAll(message: { method: string, payload: { tracks: AudioTrack[] } }) {
@@ -39,19 +41,6 @@ function handleSyncTrack(message: { method: string, payload: Partial<AudioTrack>
 
 onMounted(async () => {
   await auth.checkAuthStatus()
-
-  if (auth.role === 'gm') {
-    setTitle('My Table')
-    setActions([TableActions])
-  } else {
-    setTitle('Game Session')
-  }
-
-  if (auth.authenticated && auth.role === 'gm') {
-    audioStore.enabled = true
-  } else {
-    audioStore.enabled = false
-  }
 
   // Add WebSocket message handlers
   wsStore.addMessageHandler(handleSyncAll)
@@ -83,13 +72,12 @@ onUnmounted(() => {
 
     <!-- Player View -->
     <template v-else-if="isPlayerView">
-      <PlayerView />
+      <TableViewPlayer />
     </template>
 
     <!-- GM View -->
-    <template v-else-if="auth.authenticated && auth.role === 'gm'">
-      <AudioPlayer />
-      <FileList />
+    <template v-else-if="isGMView">
+      <TableViewGM />
     </template>
 
     <!-- Not Authenticated -->

--- a/ui/src/views/TableView.vue
+++ b/ui/src/views/TableView.vue
@@ -1,80 +1,100 @@
 <script setup lang="ts">
-import { useAudioStore } from '@/stores/audio'
-import { onMounted, onUnmounted, ref } from 'vue'
+import { useAudioStore, type AudioTrack } from '@/stores/audio'
+import { useWebSocketStore } from '@/stores/websocket'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
 import AudioPlayer from '../components/AudioPlayer.vue'
 import FileList from '../components/FileList.vue'
 import TableActions from '../components/TableActions.vue'
+import PlayerView from './PlayerView.vue'
 import { useAppBar } from '../composables/useAppBar'
-import { useBaseUrl } from '../composables/useBaseUrl'
 import { useAuthStore } from '../stores/auth'
 import { useJoinStore } from '../stores/join'
 
 const auth = useAuthStore()
 const joinStore = useJoinStore()
+const wsStore = useWebSocketStore()
 const audioStore = useAudioStore()
-const { getBaseUrl } = useBaseUrl()
 const { setTitle, setActions } = useAppBar()
 
-const joinUrl = ref<string>('')
-const isCopied = ref(false)
+const joiningWithToken = ref(false)
 
-async function copyToClipboard(text: string) {
-  if (navigator.clipboard) {
-    await navigator.clipboard.writeText(text)
+const isPlayerView = computed(() => {
+  return auth.role === 'player' || !auth.authenticated
+})
+
+function handleSyncAll(message: { method: string, payload: { tracks: AudioTrack[] } }) {
+  if (message.method === 'syncAll' && message.payload.tracks) {
+    console.log('handleSyncAll', message)
+    audioStore.syncTracks(message.payload.tracks)
+  }
+}
+
+function handleSyncTrack(message: { method: string, payload: Partial<AudioTrack> }) {
+  if (message.method === 'syncTrack' && message.payload.fileID) {
+    console.log('handleSyncTrack', message)
+    const { fileID, ...updates } = message.payload
+    audioStore.updateTrackState(fileID, updates)
+  }
+}
+
+onMounted(async () => {
+  await auth.checkAuthStatus()
+
+  if (auth.role === 'gm') {
+    setTitle('My Table')
+    setActions([TableActions])
   } else {
-    const textArea = document.createElement('textarea')
-    textArea.value = text
-    document.body.appendChild(textArea)
-    textArea.focus()
-    textArea.select()
-    try {
-      document.execCommand('copy')
-    } catch (err) {
-      console.error('Fallback: Oops, unable to copy', err)
-    }
-    document.body.removeChild(textArea)
+    setTitle('Game Session')
   }
-}
 
-async function handleGetJoinToken() {
-  await joinStore.fetchToken()
-  if (joinStore.token) {
-    const url = `${getBaseUrl()}/join/${joinStore.token}`
-    await copyToClipboard(url)
-    joinUrl.value = url
-    isCopied.value = true
-    setTimeout(() => {
-      isCopied.value = false
-    }, 2000)
+  if (auth.authenticated && auth.role === 'gm') {
+    audioStore.enabled = true
+  } else {
+    audioStore.enabled = false
   }
-}
 
-onMounted(() => {
-  setTitle('My Table')
-  setActions([TableActions])
-  audioStore.enabled = true
+  // Add WebSocket message handlers
+  wsStore.addMessageHandler(handleSyncAll)
+  wsStore.addMessageHandler(handleSyncTrack)
 })
 
 onUnmounted(() => {
   setActions([])
-  setTitle('Skald Bot')
+  setTitle('RPG Audio Streamer')
+
+  // Remove WebSocket handlers
+  wsStore.removeMessageHandler(handleSyncAll)
+  wsStore.removeMessageHandler(handleSyncTrack)
 })
 </script>
 
 <template>
   <v-container class="py-2">
-    <AudioPlayer />
-    <template v-if="auth.loading">
+    <!-- Loading State -->
+    <template v-if="auth.loading || joiningWithToken">
       <div class="text-center py-12">
-        <p>Loading...</p>
+        <h2 class="text-h4 mb-4">{{ joiningWithToken ? 'Joining Table...' : 'Loading...' }}</h2>
+        <v-progress-circular indeterminate size="64"></v-progress-circular>
+        <div v-if="joinStore.error" class="mt-4 text-error">
+          {{ joinStore.error }}
+        </div>
       </div>
     </template>
 
-    <template v-else-if="auth.authenticated">
+    <!-- Player View -->
+    <template v-else-if="isPlayerView">
+      <PlayerView />
+    </template>
+
+    <!-- GM View -->
+    <template v-else-if="auth.authenticated && auth.role === 'gm'">
+      <AudioPlayer />
       <FileList />
     </template>
+
+    <!-- Not Authenticated -->
     <template v-else>
-      <p>Please login to start managing your audio files</p>
+      <p>Please <router-link to="/login">login</router-link> to start managing your audio files</p>
     </template>
   </v-container>
 </template>

--- a/ui/src/views/TableViewGM.vue
+++ b/ui/src/views/TableViewGM.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import AudioPlayer from '@/components/AudioPlayer.vue';
+import FileList from '@/components/FileList.vue';
+import TableActions from '@/components/TableActions.vue';
+import { useAppBar } from '@/composables/useAppBar';
+import { useAudioStore } from '@/stores/audio';
+import { useAuthStore } from '@/stores/auth';
+import { onMounted } from 'vue';
+
+const auth = useAuthStore()
+const audioStore = useAudioStore()
+
+const { setTitle, setActions } = useAppBar()
+
+
+onMounted(async () => {
+  await auth.checkAuthStatus()
+
+  setTitle('My Table')
+  setActions([TableActions])
+  audioStore.enabled = true
+})
+
+</script>
+
+<template>
+  <AudioPlayer />
+  <FileList />
+</template>

--- a/ui/src/views/TableViewPlayer.vue
+++ b/ui/src/views/TableViewPlayer.vue
@@ -10,6 +10,7 @@ import { useAudioStore, type AudioTrack } from '../stores/audio'
 import { useAuthStore } from '../stores/auth'
 import { useJoinStore } from '../stores/join'
 import { useBaseUrl } from '../composables/useBaseUrl'
+import { useAppBar } from '@/composables/useAppBar'
 
 const auth = useAuthStore()
 const route = useRoute()
@@ -20,6 +21,7 @@ const debugStore = useDebugStore()
 const connecting = ref(false)
 const joiningWithToken = ref(false)
 const { getBaseUrl } = useBaseUrl()
+const { setTitle } = useAppBar()
 
 const buttonLabel = computed(() => {
   if (joiningWithToken.value) return 'Joining Table...'
@@ -59,7 +61,8 @@ onMounted(async () => {
     }
   }
 
-  await auth.checkAuthStatus()
+  setTitle('Game Session')
+  audioStore.enabled = false
 
   wsStore.addMessageHandler(handleSyncAll)
   wsStore.addMessageHandler(handleSyncTrack)


### PR DESCRIPTION
This PR changes the routing rules for the frontend. Instead of having a separate `/player`, `/join/<token>`, and `/table` endpoints, these are now all collapsed to a singl `/table/<token>` endpoint. This will make things easier in a couple ways:

- A GM can just copy the URL straight from their browser bar, not just the "Get Join URL" button
- A player URL is more bookmarkable, since the token stays in the URL