### PR TITLE
chore: Group dependabot dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,13 +15,28 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    groups:
+      all-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
 
   - package-ecosystem: "npm"
     directory: "/ui"
     schedule:
       interval: weekly
+    groups:
+      all-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: weekly
+    groups:
+      all-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
This PR groups dependabot dependencies so they all happen together, which should reduce the total number of PRs made